### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/external/anp-open-sdk/test/test_unified_config.py
+++ b/external/anp-open-sdk/test/test_unified_config.py
@@ -154,7 +154,8 @@ def test_secrets():
 
         # 测试敏感信息不在普通配置中
         secrets_dict = config.secrets.to_dict()
-        logger.info(f"✅ 敏感信息字典: {secrets_dict}")
+        sanitized_secrets = {key: 'REDACTED' for key in secrets_dict.keys()}
+        logger.info(f"✅ 敏感信息字典: {sanitized_secrets}")
 
         return True
     except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/octopus/security/code-scanning/1](https://github.com/agent-network-protocol/octopus/security/code-scanning/1)

To fix the issue, we will ensure that sensitive data is not logged in clear text. Instead of logging the entire dictionary of secrets, we will log only non-sensitive metadata or a sanitized version of the data. For example, we can log the presence of keys without revealing their values. This approach maintains the utility of the log for debugging while protecting sensitive information.

Changes to be made:
1. Replace the logging of `secrets_dict` with a sanitized version that excludes sensitive values.
2. Ensure that sensitive data is redacted or replaced with placeholders (e.g., `***` or `REDACTED`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
